### PR TITLE
Feature/automated claiming and resolvement backend

### DIFF
--- a/contracts/facets/BuildingsFacet.sol
+++ b/contracts/facets/BuildingsFacet.sol
@@ -23,23 +23,33 @@ contract BuildingsFacet is Modifiers {
         uint256 readyTimestamp = block.timestamp + craftTime;
         CraftItem memory newBuilding = CraftItem(_buildingId, readyTimestamp);
         s.craftBuildings[_planetId] = newBuilding;
-        IERC20(s.metal).burnFrom(msg.sender, price[0]);
-        IERC20(s.crystal).burnFrom(msg.sender, price[1]);
-        IERC20(s.ethereus).burnFrom(msg.sender, price[2]);
+        IERC20(s.metal).burnFrom(
+            IERC721(s.planets).ownerOf(_planetId),
+            price[0]
+        );
+        IERC20(s.crystal).burnFrom(
+            IERC721(s.planets).ownerOf(_planetId),
+            price[1]
+        );
+        IERC20(s.ethereus).burnFrom(
+            IERC721(s.planets).ownerOf(_planetId),
+            price[2]
+        );
     }
 
     function claimBuilding(uint256 _planetId)
         external
-        onlyPlanetOwner(_planetId)
+        onlyPlanetOwnerOrChainRunner(_planetId)
     {
         require(
             block.timestamp >= s.craftBuildings[_planetId].readyTimestamp,
             "BuildingsFacet: not ready yet"
         );
         IBuildings(s.buildings).mint(
-            msg.sender,
+            IERC721(s.planets).ownerOf(_planetId),
             s.craftBuildings[_planetId].itemId
         );
+
         uint256 buildingId = s.craftBuildings[_planetId].itemId;
         delete s.craftBuildings[_planetId];
         IPlanets(s.planets).addBuilding(_planetId, buildingId);
@@ -57,7 +67,10 @@ contract BuildingsFacet is Modifiers {
         }
     }
 
-    function mineMetal(uint256 _planetId) external onlyPlanetOwner(_planetId) {
+    function mineMetal(uint256 _planetId)
+        external
+        onlyPlanetOwnerOrChainRunner(_planetId)
+    {
         uint256 lastClaimed = IPlanets(s.planets).getLastClaimed(_planetId, 0);
         require(
             block.timestamp > lastClaimed + 8 hours,
@@ -66,12 +79,15 @@ contract BuildingsFacet is Modifiers {
         uint256 boost = IPlanets(s.planets).getBoost(_planetId, 0);
         uint256 amountMined = 500 ether + (boost * 1e18);
         IPlanets(s.planets).mineResource(_planetId, 0, amountMined);
-        IResource(s.metal).mint(msg.sender, amountMined);
+        IResource(s.metal).mint(
+            IERC721(s.planets).ownerOf(_planetId),
+            amountMined
+        );
     }
 
     function mineCrystal(uint256 _planetId)
         external
-        onlyPlanetOwner(_planetId)
+        onlyPlanetOwnerOrChainRunner(_planetId)
     {
         uint256 lastClaimed = IPlanets(s.planets).getLastClaimed(_planetId, 1);
         require(
@@ -81,12 +97,15 @@ contract BuildingsFacet is Modifiers {
         uint256 boost = IPlanets(s.planets).getBoost(_planetId, 1);
         uint256 amountMined = 300 ether + (boost * 1e18);
         IPlanets(s.planets).mineResource(_planetId, 1, amountMined);
-        IResource(s.crystal).mint(msg.sender, amountMined);
+        IResource(s.crystal).mint(
+            IERC721(s.planets).ownerOf(_planetId),
+            amountMined
+        );
     }
 
     function mineEthereus(uint256 _planetId)
         external
-        onlyPlanetOwner(_planetId)
+        onlyPlanetOwnerOrChainRunner(_planetId)
     {
         uint256 lastClaimed = IPlanets(s.planets).getLastClaimed(_planetId, 2);
         require(
@@ -96,7 +115,10 @@ contract BuildingsFacet is Modifiers {
         uint256 boost = IPlanets(s.planets).getBoost(_planetId, 2);
         uint256 amountMined = 200 ether + (boost * 1e18);
         IPlanets(s.planets).mineResource(_planetId, 2, amountMined);
-        IResource(s.ethereus).mint(msg.sender, amountMined);
+        IResource(s.ethereus).mint(
+            IERC721(s.planets).ownerOf(_planetId),
+            amountMined
+        );
     }
 
     function getCraftBuildings(uint256 _planetId)

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -35,13 +35,16 @@ contract FleetsFacet is Modifiers {
         IERC20(s.ethereus).burnFrom(msg.sender, price[2]);
     }
 
-    function claimFleet(uint256 _planetId) external onlyPlanetOwner(_planetId) {
+    function claimFleet(uint256 _planetId)
+        external
+        onlyPlanetOwnerOrChainRunner(_planetId)
+    {
         require(
             block.timestamp >= s.craftFleets[_planetId].readyTimestamp,
             "FleetsFacet: not ready yet"
         );
         uint256 shipId = IShips(s.ships).mint(
-            msg.sender,
+            IERC721(s.planets).ownerOf(_planetId),
             s.craftFleets[_planetId].itemId
         );
         uint256 fleetId = s.craftFleets[_planetId].itemId;

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -15,7 +15,7 @@ contract FleetsFacet is Modifiers {
         external
         onlyPlanetOwner(_planetId)
     {
-        IFleets fleetsContract = IFleets(s.fleets);
+        IFleets fleetsContract = IShips(s.ships);
         uint256[3] memory price = fleetsContract.getPrice(_fleetId);
         uint256 craftTime = fleetsContract.getCraftTime(_fleetId);
         uint256 craftedFrom = fleetsContract.getCraftedFrom(_fleetId);
@@ -53,6 +53,7 @@ contract FleetsFacet is Modifiers {
         IShips(s.ships).assignShipToPlanet(shipId, _planetId);
     }
 
+    //@notice Disabled for V0.01
     function sendCargo(
         uint256 _fromPlanetId,
         uint256 _toPlanetId,
@@ -72,6 +73,7 @@ contract FleetsFacet is Modifiers {
         // emit event
     }
 
+    //@notice Disabled for V0.01
     function returnCargo(uint256 _sendCargoId) external {
         require(
             msg.sender ==
@@ -106,6 +108,7 @@ contract FleetsFacet is Modifiers {
         delete s.sendCargo[_sendCargoId];
     }
 
+    //@notice Disabled for V0.01
     function sendTerraform(
         uint256 _fromPlanetId,
         uint256 _toPlanetId,
@@ -124,6 +127,7 @@ contract FleetsFacet is Modifiers {
         // emit event
     }
 
+    //@notice Disabled for V0.01
     function endTerraform(uint256 _sendTerraformId) external {
         require(
             msg.sender ==
@@ -460,4 +464,21 @@ contract FleetsFacet is Modifiers {
             );
         }
     }
+
+    //@TODO @Marco where to offload this, probably a seperate facet?
+
+    //@TODO store alliance somewhere. (AppStorage?)
+    //@TODO join/leave a certain mapping.
+    //@TODO when attack/sending friendlies check if the owner of the Target is in the same Alliance as the owner.
+    //@TODO Getter Function if target is friendly
+    //@TODO Getter Function available alliances and their members.
+    //@TODO
+
+    function createAlliance() external {}
+
+    function joinAlliance() external {}
+
+    function leaveAlliance() external {}
+
+    function checkAlliance() external {}
 }

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -15,7 +15,7 @@ contract FleetsFacet is Modifiers {
         external
         onlyPlanetOwner(_planetId)
     {
-        IFleets fleetsContract = IShips(s.ships);
+        IShips fleetsContract = IShips(s.ships);
         uint256[3] memory price = fleetsContract.getPrice(_fleetId);
         uint256 craftTime = fleetsContract.getCraftTime(_fleetId);
         uint256 craftedFrom = fleetsContract.getCraftedFrom(_fleetId);

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -375,6 +375,25 @@ contract FleetsFacet is Modifiers {
                     delete attackerShips[i];
                 }
             }
+
+            //sending ships home
+
+            for (uint256 i = 0; i < attackerShips.length; i++) {
+                IShips(s.ships).assignShipToPlanet(
+                    attackerShips[i],
+                    attackToResolve.fromPlanet
+                );
+            }
+
+            //update planet defense array mapping @TODO remove / refactor
+            IPlanets(s.planets).assignDefensePlanet(
+                attackToResolve.fromPlanet,
+                attackerShips
+            );
+
+            IPlanets(s.planets).resolveLostAttack(
+                attackToResolve.attackInstanceId
+            );
         }
 
         //draw -> currently leads to zero losses, only a retreat

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -54,6 +54,7 @@ contract FleetsFacet is Modifiers {
     }
 
     //@notice Disabled for V0.01
+    /*
     function sendCargo(
         uint256 _fromPlanetId,
         uint256 _toPlanetId,
@@ -72,8 +73,9 @@ contract FleetsFacet is Modifiers {
         s.sendCargo[s.sendCargoId] = newSendCargo;
         // emit event
     }
-
+    */
     //@notice Disabled for V0.01
+    /*
     function returnCargo(uint256 _sendCargoId) external {
         require(
             msg.sender ==
@@ -107,8 +109,10 @@ contract FleetsFacet is Modifiers {
         IResource(s.ethereus).mint(msg.sender, cargo);
         delete s.sendCargo[_sendCargoId];
     }
-
+    */
     //@notice Disabled for V0.01
+
+    /*
     function sendTerraform(
         uint256 _fromPlanetId,
         uint256 _toPlanetId,
@@ -126,8 +130,9 @@ contract FleetsFacet is Modifiers {
         s.sendTerraform[s.sendTerraformId] = newSendTerraform;
         // emit event
     }
-
+    */
     //@notice Disabled for V0.01
+    /*
     function endTerraform(uint256 _sendTerraformId) external {
         require(
             msg.sender ==
@@ -152,7 +157,7 @@ contract FleetsFacet is Modifiers {
         );
         //todo: conquer planet
     }
-
+    */
     function getCraftFleets(uint256 _planetId)
         external
         view

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -216,6 +216,8 @@ contract FleetsFacet is Modifiers {
     }
 
     //@TODO for guilds the target doesnt need to be the planet owner as well, alliance member / friendly status / sth
+    //@TODO currently instantenous for hackathon.
+    //@notice perhaps require a specific building for instantenous travel / normal travel for others>
 
     function sendFriendlies(
         uint256 _fromPlanetId,
@@ -232,7 +234,14 @@ contract FleetsFacet is Modifiers {
 
             //unassign ships during attack
             IShips(s.ships).deleteShipFromPlanet(_shipIds[i]);
-            unAssignNewShipTypeAmount(_fromPlanetId, _shipIds);
+        }
+
+        unAssignNewShipTypeAmount(_fromPlanetId, _shipIds);
+
+        AssignNewShipTypeAmount(_toPlanetId, _shipIds);
+
+        for (uint256 i = 0; i < attackerShips.length; i++) {
+            IShips(s.ships).assignShipToPlanet(_shipIds[i], _toPlanetId);
         }
     }
 

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -365,43 +365,20 @@ contract FleetsFacet is Modifiers {
 
         //defender has higher atk than attacker
         if (battleResult < 0) {
-            //burn nfts and unassign ship from planets, also reduce defenderShip Array
-            for (uint256 i = 0; i < defenderShips.length; i++) {
-                uint256 defenderShipHealth = IShips(s.ships)
-                    .getShipStats(defenderShips[i])
+            //burn attacker nfts that lost
+            for (uint256 i = 0; i < attackerShips.length; i++) {
+                uint256 attackerShipHealth = IShips(s.ships)
+                    .getShipStats(attackerShips[i])
                     .health;
 
-                if (battleResult > defenderShipHealth) {
-                    battleResult -= defenderShipHealth;
+                if (battleResult > attackerShipHealth) {
+                    battleResult -= attackerShipHealth;
 
-                    IShips(s.ships).burnShip(defenderShips[i]);
-                    IShips(s.ships).deleteShipFromPlanet([defenderShips[i]]);
-                    delete defenderShips[i];
+                    IShips(s.ships).burnShip(attackerShips[i]);
+                    IShips(s.ships).deleteShipFromPlanet([attackerShips[i]]);
+                    delete attackerShips[i];
                 }
             }
-
-            //update planet defense array mapping @TODO remove / refactor
-            IPlanets(s.planets).assignDefensePlanet(
-                attackToResolve.toPlanet,
-                defenderShips
-            );
-
-            for (uint256 i = 0; i < attackerShips.length; i++) {
-                IShips(s.ships).assignShipToPlanet(
-                    attackerShips[i],
-                    attackToResolve.fromPlanet
-                );
-            }
-
-            //update planet defense array mapping @TODO remove / refactor
-            IPlanets(s.planets).assignDefensePlanet(
-                attackToResolve.fromPlanet,
-                attackerShips
-            );
-
-            IPlanets(s.planets).resolveLostAttack(
-                attackToResolve.attackInstanceId
-            );
         }
 
         //draw -> currently leads to zero losses, only a retreat

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -180,8 +180,8 @@ contract FleetsFacet is Modifiers {
 
             //unassign ships during attack
             IShips(s.ships).deleteShipFromPlanet(_shipIds[i]);
-            unAssignNewShipTypeAmount(_fromPlanetId, _shipIds);
         }
+        unAssignNewShipTypeAmount(_fromPlanetId, _shipIds);
 
         //refactor to  an internal func
 
@@ -215,11 +215,26 @@ contract FleetsFacet is Modifiers {
         IPlanets(s.planets).addAttack(attackToBeAdded);
     }
 
-    function sendFriendlies(uint256 _fromPlanetId, uint256 _toPlanetId)
-        external
-        onlyPlanetOwner(_fromPlanetId)
-        onlyPlanetOwner(_toPlanetId)
-    {}
+    //@TODO for guilds the target doesnt need to be the planet owner as well, alliance member / friendly status / sth
+
+    function sendFriendlies(
+        uint256 _fromPlanetId,
+        uint256 _toPlanetId,
+        uint256[] memory _shipIds
+    ) external onlyPlanetOwner(_fromPlanetId) onlyPlanetOwner(_toPlanetId) {
+        //check if ships are assigned to the planet
+        for (uint256 i = 0; i < _shipIds.length; i++) {
+            require(
+                IShips(s.ships).checkAssignedPlanet(_shipIds[i]) ==
+                    _fromPlanetId,
+                "ship is not assigned to this planet!"
+            );
+
+            //unassign ships during attack
+            IShips(s.ships).deleteShipFromPlanet(_shipIds[i]);
+            unAssignNewShipTypeAmount(_fromPlanetId, _shipIds);
+        }
+    }
 
     function assignNewShipTypeAmount(
         uint256 _toPlanetId,

--- a/contracts/facets/FleetsFacet.sol
+++ b/contracts/facets/FleetsFacet.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.17;
 
 import {AppStorage, Modifiers, CraftItem, SendCargo, SendTerraform, attackStatus, ShipType} from "../libraries/AppStorage.sol";
 import "../interfaces/IPlanets.sol";
-import "../interfaces/IFleets.sol";
-
 import "../interfaces/IShips.sol";
 import "../interfaces/IERC20.sol";
 import "../interfaces/IERC721.sol";

--- a/contracts/interfaces/IPlanets.sol
+++ b/contracts/interfaces/IPlanets.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
+import {attackStatus} from "../libraries/AppStorage.sol";
 
 interface IPlanets {
     struct Planet {
@@ -59,7 +60,9 @@ interface IPlanets {
         uint256 _attackIdResolved
     ) external;
 
-    function getDefensePlanet(uint256 planetId) external;
+    function getDefensePlanet(uint256 planetId)
+        external
+        returns (uint256[] memory);
 
     function assignDefensePlanet(
         uint256 _planetId,
@@ -67,4 +70,11 @@ interface IPlanets {
     ) external;
 
     function resolveLostAttack(uint256 attackIdResolved) external;
+
+    function addAttack(attackStatus memory _attackToBeInitated) external;
+
+    function getAttackStatus(uint256 _instanceId)
+        external
+        view
+        returns (attackStatus memory);
 }

--- a/contracts/interfaces/IPlanets.sol
+++ b/contracts/interfaces/IPlanets.sol
@@ -17,8 +17,14 @@ interface IPlanets {
 
     function addFleet(
         uint256 _planetId,
-        uint256 _fleetId,
-        uint256 _tokenId
+        uint256 _shipType,
+        uint256 amount
+    ) external;
+
+    function removeFleet(
+        uint256 _planetId,
+        uint256 _shipType,
+        uint256 amount
     ) external;
 
     function getBuildings(uint256 _planetId, uint256 _buildingId)
@@ -63,11 +69,6 @@ interface IPlanets {
     function getDefensePlanet(uint256 planetId)
         external
         returns (uint256[] memory);
-
-    function assignDefensePlanet(
-        uint256 _planetId,
-        uint256[] memory _newDefenseShips
-    ) external;
 
     function resolveLostAttack(uint256 attackIdResolved) external;
 

--- a/contracts/interfaces/IPlanets.sol
+++ b/contracts/interfaces/IPlanets.sol
@@ -14,7 +14,11 @@ interface IPlanets {
 
     function addBuilding(uint256 _planetId, uint256 _buildingId) external;
 
-    function addFleet(uint256 _planetId, uint256 _fleetId) external;
+    function addFleet(
+        uint256 _planetId,
+        uint256 _fleetId,
+        uint256 _tokenId
+    ) external;
 
     function getBuildings(uint256 _planetId, uint256 _buildingId)
         external
@@ -47,4 +51,20 @@ interface IPlanets {
         external
         view
         returns (uint256, uint256);
+
+    function planetConquestTransfer(
+        uint256 _tokenId,
+        address _oldOwner,
+        address _newOwner,
+        uint256 _attackIdResolved
+    ) external;
+
+    function getDefensePlanet(uint256 planetId) external;
+
+    function assignDefensePlanet(
+        uint256 _planetId,
+        uint256[] memory _newDefenseShips
+    ) external;
+
+    function resolveLostAttack(uint256 attackIdResolved) external;
 }

--- a/contracts/interfaces/IShips.sol
+++ b/contracts/interfaces/IShips.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IShips {
+    function mint(address _account, uint256 _shipTypeId)
+        external
+        returns (uint256);
+
+    function getPrice(uint256 _fleetId)
+        external
+        view
+        returns (uint256[3] memory);
+
+    struct ShipType {
+        uint256[3] price; // [metal, crystal, ethereus]
+        uint256 attack;
+        uint256 health;
+        uint256 cargo;
+        uint256 craftTime;
+        uint256 craftedFrom;
+        string name;
+    }
+
+    function getCraftTime(uint256 _fleetId) external view returns (uint256);
+
+    function getCraftedFrom(uint256 _fleetId) external view returns (uint256);
+
+    function getCargo(uint256 _fleetId) external view returns (uint256);
+
+    function burnShip(uint256 _shipId) external;
+
+    function assignShipToPlanet(uint256 _shipId, uint256 _toPlanetId) external;
+
+    function deleteShipFromPlanet(uint256 _shipId) external;
+
+    function getShipStats(uint256 _shipId)
+        external
+        view
+        returns (ShipType memory);
+
+    function checkAssignedPlanet(uint256 _shipId)
+        external
+        view
+        returns (uint256);
+}

--- a/contracts/interfaces/IShips.sol
+++ b/contracts/interfaces/IShips.sol
@@ -12,6 +12,7 @@ interface IShips {
         returns (uint256[3] memory);
 
     struct ShipType {
+        uint256 shipType;
         uint256[3] price; // [metal, crystal, ethereus]
         uint256 attack;
         uint256 health;
@@ -19,6 +20,13 @@ interface IShips {
         uint256 craftTime;
         uint256 craftedFrom;
         string name;
+        uint256 moduleSlots;
+        ShipModule[] equippedShipModule;
+    }
+
+    struct ShipModule {
+        uint256 attackBoostStat;
+        uint256 healthBoostStat;
     }
 
     function getCraftTime(uint256 _fleetId) external view returns (uint256);
@@ -42,4 +50,7 @@ interface IShips {
         external
         view
         returns (uint256);
+
+
+    function getDefensePlanet(uint256 _planetId) external view returns (uint256[] memory)
 }

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -43,6 +43,24 @@ struct attackStatus {
     uint256 attackInstanceId;
 }
 
+struct ShipType {
+    uint256 shipType;
+    uint256[3] price; // [metal, crystal, ethereus]
+    uint256 attack;
+    uint256 health;
+    uint256 cargo;
+    uint256 craftTime;
+    uint256 craftedFrom;
+    string name;
+    uint256 moduleSlots;
+    ShipModule[] equippedShipModule;
+}
+
+struct ShipModule {
+    uint256 attackBoostStat;
+    uint256 healthBoostStat;
+}
+
 struct AppStorage {
     address crystal;
     address ethereus;

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -76,6 +76,11 @@ struct AppStorage {
     mapping(uint256 => SendCargo) sendCargo;
     // sendTerraformId => SendTerraform
     mapping(uint256 => SendTerraform) sendTerraform;
+    //alliance Mappings
+    mapping(address => bool) isInvited;
+    mapping(bytes32 => address) allianceOwner;
+    mapping(address => bytes32) allianceOfPlayer;
+    mapping(bytes23 => uint256) allianceMemberCount;
     uint256 sendCargoId;
     uint256 sendTerraformId;
     // heroId => vrf/reg data

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -32,6 +32,17 @@ struct RequestConfig {
     bytes32 keyHash;
 }
 
+struct attackStatus {
+    uint256 attackStarted;
+    uint256 distance;
+    uint256 timeToBeResolved;
+    uint256 fromPlanet;
+    uint256 toPlanet;
+    uint256[] attackerShipsIds;
+    address attacker;
+    uint256 attackInstanceId;
+}
+
 struct AppStorage {
     address crystal;
     address ethereus;

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -90,6 +90,9 @@ struct AppStorage {
     address vrfCoordinator;
     address linkAddress;
     RequestConfig requestConfig;
+    //@TODO add to deployment script. this is our backend account able to claim for players / resolve attacks.
+    //@notice this does not represent an attack vector, since the actions dont mint/generate anything for msg.sender, they only cost gas.
+    address chainRunner;
 }
 
 library LibAppStorage {
@@ -111,6 +114,16 @@ contract Modifiers {
     modifier onlyPlanetOwner(uint256 _planetId) {
         require(
             msg.sender == IERC721(s.planets).ownerOf(_planetId),
+            "AppStorage: Not owner"
+        );
+        _;
+    }
+
+    modifier onlyPlanetOwnerOrChainRunner(uint256 _planetId) {
+        require(
+            msg.sender == IERC721(s.planets).ownerOf(_planetId) ||
+                //@TODO @notice @Marco , How can I reference the address variable from above? This way?
+                msg.sender == s.chainRunner,
             "AppStorage: Not owner"
         );
         _;

--- a/contracts/libraries/AppStorage.sol
+++ b/contracts/libraries/AppStorage.sol
@@ -50,6 +50,7 @@ struct AppStorage {
     address buildings;
     address fleets;
     address planets;
+    address ships;
     mapping(address => bool) registered;
     mapping(uint256 => CraftItem) craftBuildings;
     mapping(uint256 => CraftItem) craftFleets;

--- a/contracts/other/Planets.sol
+++ b/contracts/other/Planets.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -32,8 +32,6 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
     mapping(uint256 => Planet) public planets;
     // planetId => fleetId => amount
     mapping(uint256 => mapping(uint256 => uint256)) public fleets;
-    //planetId  => shipIds
-    mapping(uint256 => uint256[]) public fleetShipIds;
 
     // planetId => buildingId => amount
     mapping(uint256 => mapping(uint256 => uint256)) public buildings;
@@ -95,22 +93,18 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
 
     function addFleet(
         uint256 _planetId,
-        uint256 _fleetId,
         uint256 _shipType,
         uint256 amount
     ) external onlyGameDiamond {
-        fleets[_planetId][_fleetId] += amount;
-        fleetShipIds[_planetId].push(_tokenId);
+        fleets[_planetId][_shipType] += amount;
     }
 
     function removeFleet(
         uint256 _planetId,
-        uint256 _fleetId,
         uint256 _shipType,
         uint256 amount
     ) external onlyGameDiamond {
-        fleets[_planetId][_fleetId] -= amount;
-        fleetShipIds[_planetId].push(_tokenId);
+        fleets[_planetId][_shipType] -= amount;
     }
 
     function addBoost(
@@ -186,13 +180,6 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         returns (uint256[] memory)
     {
         return fleetShipIds[_planetId];
-    }
-
-    function assignDefensePlanet(
-        uint256 _planetId,
-        uint256[] memory _newDefenseShips
-    ) external onlyGameDiamond {
-        fleetShipIds[_planetId] = _newDefenseShips;
     }
 
     function addAttack(attackStatus memory _attackToBeInitated)

--- a/contracts/other/Planets.sol
+++ b/contracts/other/Planets.sol
@@ -12,6 +12,19 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         uint256 ethereus;
         uint256 metal;
         uint256 crystal;
+        bool pvpEnabled;
+        address owner;
+    }
+
+    struct attackStatus {
+        uint256 attackStarted;
+        uint256 distance;
+        uint256 timeToBeResolved;
+        uint256 fromPlanet;
+        uint256 toPlanet;
+        uint256[] attackerShipsIds;
+        address attacker;
+        uint256 attackInstanceId;
     }
 
     address public gameDiamond;
@@ -19,6 +32,9 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
     mapping(uint256 => Planet) public planets;
     // planetId => fleetId => amount
     mapping(uint256 => mapping(uint256 => uint256)) public fleets;
+    //planetId  => shipIds
+    mapping(uint256 => uint256[]) public fleetShipIds;
+
     // planetId => buildingId => amount
     mapping(uint256 => mapping(uint256 => uint256)) public buildings;
     // planetId => resource => boost
@@ -27,6 +43,23 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
     mapping(uint256 => mapping(uint256 => uint256)) public lastClaimed;
 
     string private _uri;
+
+    attackStatus[] public runningAttacks;
+
+    event planetConquered(
+        uint256 indexed tokenId,
+        address indexed oldOwner,
+        address indexed newOwner
+    );
+
+    event attackInitated(
+        uint256 indexed attackedPlanet,
+        address indexed Attacker,
+        uint256 indexed timeToArrive,
+        uint256 arrayIndex
+    );
+
+    event attackLost(uint256 indexed attackedPlanet, address indexed Attacker);
 
     function initialize(address _gameDiamond) public initializer {
         __ERC721_init("Planets", "PLN");
@@ -42,29 +75,49 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         return _uri;
     }
 
-    function mint(Planet calldata _planet) external {
+    modifier onlyGameDiamond() {
         require(msg.sender == gameDiamond, "Planets: restricted");
+        _;
+    }
+
+    function mint(Planet calldata _planet) external onlyGameDiamond {
         uint256 planetId = totalSupply() + 1;
         planets[planetId] = _planet;
         _safeMint(msg.sender, planetId);
     }
 
-    function addBuilding(uint256 _planetId, uint256 _buildingId) external {
-        require(msg.sender == gameDiamond, "Planets: restricted");
+    function addBuilding(uint256 _planetId, uint256 _buildingId)
+        external
+        onlyGameDiamond
+    {
         buildings[_planetId][_buildingId] += 1;
     }
 
-    function addFleet(uint256 _planetId, uint256 _fleetId) external {
-        require(msg.sender == gameDiamond, "Planets: restricted");
-        fleets[_planetId][_fleetId] += 1;
+    function addFleet(
+        uint256 _planetId,
+        uint256 _fleetId,
+        uint256 _shipType,
+        uint256 amount
+    ) external onlyGameDiamond {
+        fleets[_planetId][_fleetId] += amount;
+        fleetShipIds[_planetId].push(_tokenId);
+    }
+
+    function removeFleet(
+        uint256 _planetId,
+        uint256 _fleetId,
+        uint256 _shipType,
+        uint256 amount
+    ) external onlyGameDiamond {
+        fleets[_planetId][_fleetId] -= amount;
+        fleetShipIds[_planetId].push(_tokenId);
     }
 
     function addBoost(
         uint256 _planetId,
         uint256 _resourceId,
         uint256 _boost
-    ) external {
-        require(msg.sender == gameDiamond, "Planets: restricted");
+    ) external onlyGameDiamond {
         boosts[_planetId][_resourceId] += _boost;
     }
 
@@ -72,8 +125,7 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         uint256 _planetId,
         uint256 _resourceId,
         uint256 _amount
-    ) external {
-        require(msg.sender == gameDiamond, "Planets: restricted");
+    ) external onlyGameDiamond {
         if (_resourceId == 0) {
             planets[_planetId].metal -= _amount;
         } else if (_resourceId == 1) {
@@ -94,6 +146,14 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         returns (uint256)
     {
         return buildings[_planetId][_buildingId];
+    }
+
+    function getAttackStatus(uint256 _instanceId)
+        external
+        view
+        returns (attackStatus memory)
+    {
+        return runningAttacks[_instanceId];
     }
 
     function getLastClaimed(uint256 _planetId, uint256 _resourceId)
@@ -118,5 +178,58 @@ contract Planets is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         returns (uint256, uint256)
     {
         return (planets[_planetId].coordinateX, planets[_planetId].coordinateY);
+    }
+
+    function getDefensePlanet(uint256 _planetId)
+        external
+        view
+        returns (uint256[] memory)
+    {
+        return fleetShipIds[_planetId];
+    }
+
+    function assignDefensePlanet(
+        uint256 _planetId,
+        uint256[] memory _newDefenseShips
+    ) external onlyGameDiamond {
+        fleetShipIds[_planetId] = _newDefenseShips;
+    }
+
+    function addAttack(attackStatus memory _attackToBeInitated)
+        external
+        onlyGameDiamond
+    {
+        _attackToBeInitated.attackInstanceId = runningAttacks.length;
+        runningAttacks.push(_attackToBeInitated);
+
+        emit attackInitated(
+            _attackToBeInitated.toPlanet,
+            _attackToBeInitated.attacker,
+            _attackToBeInitated.timeToBeResolved,
+            runningAttacks.length - 1
+        );
+    }
+
+    function planetConquestTransfer(
+        uint256 _tokenId,
+        address _oldOwner,
+        address _newOwner,
+        uint256 _attackIdResolved
+    ) external onlyGameDiamond {
+        delete runningAttacks[_attackIdResolved];
+        _safeTransfer(_oldOwner, _newOwner, _tokenId, "");
+        emit planetConquered(_tokenId, _oldOwner, _newOwner);
+    }
+
+    function resolveLostAttack(uint256 _attackIdResolved)
+        external
+        onlyGameDiamond
+    {
+        emit attackLost(
+            runningAttacks[_attackIdResolved].toPlanet,
+            runningAttacks[_attackIdResolved].attacker
+        );
+
+        delete runningAttacks[_attackIdResolved];
     }
 }

--- a/contracts/other/Ships.sol
+++ b/contracts/other/Ships.sol
@@ -9,6 +9,7 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
     address public gameDiamond;
 
     struct ShipType {
+        uint256 shipType;
         uint256[3] price; // [metal, crystal, ethereus]
         uint256 attack;
         uint256 health;
@@ -16,7 +17,7 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         uint256 craftTime;
         uint256 craftedFrom;
         string name;
-        uint moduleSlots;
+        uint256 moduleSlots;
         ShipModule[] equippedShipModule;
     }
 
@@ -26,12 +27,12 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
     }
 
     //what kind of ship each tokenId actually is
-
     mapping(uint256 => ShipType) public SpaceShips;
 
     //shipId => planetId
     mapping(uint256 => uint256) public assignedPlanet;
 
+    //ship categories template
     mapping(uint256 => ShipType) public shipType;
 
     string private _uri;
@@ -61,10 +62,10 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
 
     //done
     //@param
-    function mint(address _account, uint _shipTypeId)
+    function mint(address _account, uint256 _shipTypeId)
         external
         onlyGameDiamond
-        returns (uint)
+        returns (uint256)
     {
         uint256 shipId = totalSupply() + 1;
         SpaceShips[shipId] = shipType[_shipTypeId];
@@ -89,7 +90,7 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         return assignedPlanet[_shipId];
     }
 
-    function assignShipToPlanet(uint256 _shipId, uint _toPlanetId)
+    function assignShipToPlanet(uint256 _shipId, uint256 _toPlanetId)
         external
         onlyGameDiamond
     {
@@ -130,5 +131,28 @@ contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
         returns (ShipType memory)
     {
         return SpaceShips[_shipId];
+    }
+
+    function getDefensePlanet(uint256 _planetId)
+        external
+        view
+        returns (uint256[] memory)
+    {
+        //@TODO to be refactored / removed / fixed / solved differently
+        uint256 totalFleetSize;
+        for (uint256 i = 0; i < totalSupply() + 1; i++) {
+            if (assignedPlanet[i] == _planetId) {
+                totalFleetSize += 1;
+            }
+        }
+        uint256[] memory defenseFleetToReturn = new uint256[](totalFleetSize);
+
+        for (uint256 i = 0; i < totalSupply() + 1; i++) {
+            if (assignedPlanet[i] == _planetId) {
+                defenseFleetToReturn = i;
+            }
+        }
+
+        return defenseFleetToReturn;
     }
 }

--- a/contracts/other/Ships.sol
+++ b/contracts/other/Ships.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+
+contract Ships is ERC721EnumerableUpgradeable, OwnableUpgradeable {
+    address public gameDiamond;
+
+    struct ShipType {
+        uint256[3] price; // [metal, crystal, ethereus]
+        uint256 attack;
+        uint256 health;
+        uint256 cargo;
+        uint256 craftTime;
+        uint256 craftedFrom;
+        string name;
+        uint moduleSlots;
+        ShipModule[] equippedShipModule;
+    }
+
+    struct ShipModule {
+        uint256 attackBoostStat;
+        uint256 healthBoostStat;
+    }
+
+    //what kind of ship each tokenId actually is
+
+    mapping(uint256 => ShipType) public SpaceShips;
+
+    //shipId => planetId
+    mapping(uint256 => uint256) public assignedPlanet;
+
+    mapping(uint256 => ShipType) public shipType;
+
+    string private _uri;
+
+    modifier onlyGameDiamond() {
+        require(msg.sender == gameDiamond, "Planets: restricted");
+        _;
+    }
+
+    function initialize(address _gameDiamond) public initializer {
+        __ERC721_init("Ships", "SHIP");
+        __Ownable_init();
+        gameDiamond = _gameDiamond;
+    }
+
+    function setUri(string calldata __uri) external onlyOwner {
+        _uri = __uri;
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _uri;
+    }
+
+    function setAddresses(address _gameDiamond) external onlyOwner {
+        gameDiamond = _gameDiamond;
+    }
+
+    //done
+    //@param
+    function mint(address _account, uint _shipTypeId)
+        external
+        onlyGameDiamond
+        returns (uint)
+    {
+        uint256 shipId = totalSupply() + 1;
+        SpaceShips[shipId] = shipType[_shipTypeId];
+
+        _safeMint(_account, shipId);
+
+        return (shipId);
+    }
+
+    function addShipType(uint256 _id, ShipType calldata _newShipType)
+        external
+        onlyOwner
+    {
+        shipType[_id] = _newShipType;
+    }
+
+    function checkAssignedPlanet(uint256 _shipId)
+        external
+        view
+        returns (uint256)
+    {
+        return assignedPlanet[_shipId];
+    }
+
+    function assignShipToPlanet(uint256 _shipId, uint _toPlanetId)
+        external
+        onlyGameDiamond
+    {
+        assignedPlanet[_shipId] = _toPlanetId;
+    }
+
+    function deleteShipFromPlanet(uint256 _shipId) external onlyGameDiamond {
+        delete assignedPlanet[_shipId];
+    }
+
+    function getPrice(uint256 _fleetId)
+        external
+        view
+        returns (uint256[3] memory)
+    {
+        return shipType[_fleetId].price;
+    }
+
+    function getCraftTime(uint256 _fleetId) external view returns (uint256) {
+        return shipType[_fleetId].craftTime;
+    }
+
+    function getCraftedFrom(uint256 _fleetId) external view returns (uint256) {
+        return shipType[_fleetId].craftedFrom;
+    }
+
+    function getCargo(uint256 _fleetId) external view returns (uint256) {
+        return shipType[_fleetId].cargo;
+    }
+
+    function burnShip(uint256 _shipId) external onlyGameDiamond {
+        _burn(_shipId);
+    }
+
+    function getShipStats(uint256 _shipId)
+        external
+        view
+        returns (ShipType memory)
+    {
+        return SpaceShips[_shipId];
+    }
+}


### PR DESCRIPTION
based on PR feature/attacking-and-defending


This enables our backend wallet/keys to claim fleets / claim buildings / mine for users.

Usually I would add events for our backend to pickup and save the timestamp on when its supposed to be resolved, but I can also do the brute-force method of checking if a transaction wouldnt revert.

Backend will be in a seperate (tbc) Repo



@marcoruggeri  

Would need your input on the appStorage variable access, not sure if I used it correctly.



```
 //@TODO add to deployment script. this is our backend account able to claim for players / resolve attacks.
    //@notice this does not represent an attack vector, since the actions dont mint/generate anything for msg.sender, they only cost gas.
    address chainRunner;
}

library LibAppStorage {
@@ -115,4 +118,14 @@ contract Modifiers {
        );
        _;
    }

    modifier onlyPlanetOwnerOrChainRunner(uint256 _planetId) {
        require(
            msg.sender == IERC721(s.planets).ownerOf(_planetId) ||
                //@TODO @notice @Marco , How can I reference the address variable from above? This way?
                msg.sender == s.chainRunner,
            "AppStorage: Not owner"
        );
        _;
    }
```

